### PR TITLE
feat: add sentry wrapper for onTaskDispatched

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -44,6 +44,6 @@
     }
   ],
   "tui": {
-    "enabled": true
+    "enabled": false
   }
 }

--- a/packages/sentry/README.md
+++ b/packages/sentry/README.md
@@ -92,6 +92,21 @@ export const dailyCleanup = onSchedule(
 )
 ```
 
+#### Task Queue Function
+
+```typescript
+import { onTaskDispatched } from 'firebase-functions/v2/tasks'
+import { sentryWrapOnTaskDispatched } from '@valian/node-sentry'
+
+export const processTask = onTaskDispatched(
+  { retryConfig: { maxAttempts: 3 } },
+  sentryWrapOnTaskDispatched({ name: 'processTask' }, async (request) => {
+    const taskData = request.data
+    // Your task processing logic here
+  }),
+)
+```
+
 ### Firebase Functions v1
 
 #### Firestore Trigger
@@ -277,6 +292,7 @@ wrapperFunction({ name: 'functionName' }, async (event, context?) => {
 - `sentryWrapOnDocumentChange` - Firestore document changes
 - `sentryWrapOnMessagePublished` - PubSub messages
 - `sentryWrapOnSchedule` - Scheduled functions
+- `sentryWrapOnTaskDispatched` - Task queue functions
 
 #### V1 Wrappers
 


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Added Sentry wrapper for Firebase Functions v2 Task Queue (`onTaskDispatched`), completing the coverage of v2 function types.

The implementation:
- Follows established patterns from other v2 wrappers (particularly `sentryWrapOnSchedule`)
- Properly tracks task context (id, queueName, retryCount, data)
- Uses correct operation name `on-task-dispatched`
- Includes comprehensive tests covering functionality, context, and error handling
- Automatically exports through existing `index.ts`

The `nx.json` TUI setting change appears unrelated to the feature.

<h3>Confidence Score: 5/5</h3>


- Safe to merge - well-tested implementation following established patterns
- The implementation is consistent with existing v2 wrappers, includes comprehensive test coverage, and follows TypeScript best practices. No breaking changes or issues detected.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/sentry/src/sentry-wrapper.ts | Added `sentryWrapOnTaskDispatched` wrapper following established v2 patterns with proper context tracking |
| packages/sentry/src/__tests__/sentry-wrapper.spec.ts | Added comprehensive tests for Task v2 handler covering basic functionality, context setting, and operation naming |
| nx.json | Disabled Nx TUI - unrelated configuration change |

</details>



<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->