### PR TITLE
feat: add @valian/pino-logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,18 @@ A smart logger wrapper for Firebase Functions that automatically switches betwee
 
 [View Documentation](./packages/logger/README.md)
 
+### [@valian/pino-logger](./packages/pino-logger)
+
+A pino-based logger for Firebase Functions that automatically switches between pretty output in development and forwards to the native `firebase-functions` logger in production.
+
+- 🌲 Full Pino API with child loggers, bindings, and structured logging
+- 🔄 Automatic Mode Switching between pino-pretty and Firebase logger
+- 🎯 GCP Severity Mapping with range-based level support
+- 📊 Structured JSON Logging compatible with GCP Cloud Logging
+- ⚙️ Configurable Log Levels via environment variables
+
+[View Documentation](./packages/pino-logger/README.md)
+
 ### [@valian/node-sentry](./packages/sentry)
 
 A comprehensive Sentry integration library for Firebase Functions (v1 and v2) that provides automatic error tracking, context enrichment, and performance monitoring.

--- a/packages/pino-logger/.gitignore
+++ b/packages/pino-logger/.gitignore
@@ -1,0 +1,2 @@
+coverage
+lib

--- a/packages/pino-logger/.npmignore
+++ b/packages/pino-logger/.npmignore
@@ -1,0 +1,13 @@
+/coverage/
+/src/
+!/lib/
+/tsconfig.json
+/tsconfig.*.json
+tsconfig.tsbuildinfo
+vitest.*
+rollup.config.js
+eslint.config.mjs
+.gitignore
+firebase.json
+GEMINI.md
+tsdown.config.mjs

--- a/packages/pino-logger/CHANGELOG.md
+++ b/packages/pino-logger/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Changelog

--- a/packages/pino-logger/README.md
+++ b/packages/pino-logger/README.md
@@ -1,0 +1,228 @@
+# @valian/pino-logger
+
+A pino-based logger for Firebase Functions that automatically switches between pretty output in development and forwards to the native `firebase-functions` logger in production for GCP-compatible structured logging.
+
+## Features
+
+- **Automatic Mode Switching**: Uses [pino-pretty](https://github.com/pinojs/pino-pretty) for colorized output during development and forwards to `firebase-functions/logger` in production
+- **Firebase Logger Integration**: In production, logs are forwarded to the native Firebase logger with proper GCP severity mapping
+- **Full Pino API**: Exposes a standard `pino.Logger` instance with all pino features (child loggers, bindings, etc.)
+- **Optional Pretty Printing**: `pino-pretty` is an optional peer dependency for development
+- **Configurable Log Levels**: Control verbosity via environment variables
+- **Robust Severity Mapping**: Uses range-based mapping to handle standard and custom pino levels
+
+## Installation
+
+```bash
+npm install @valian/pino-logger
+```
+
+Or with pnpm:
+
+```bash
+pnpm add @valian/pino-logger
+```
+
+### Peer Dependencies
+
+This package requires `firebase-functions` as a peer dependency (used in production for GCP logging):
+
+```bash
+pnpm add firebase-functions
+```
+
+For pretty output in development, also install `pino-pretty`:
+
+```bash
+pnpm add -D pino-pretty
+```
+
+## Usage
+
+### Basic Usage
+
+```typescript
+import { logger } from '@valian/pino-logger'
+
+// Log with context object (pino style - object first, message second)
+logger.info({ userId: '123', action: 'login' }, 'User logged in')
+
+// Log simple messages
+logger.debug('Debugging information')
+logger.info('General information')
+logger.warn('Warning message')
+logger.error('Error occurred')
+
+// Log errors with stack traces
+logger.error(error, 'Something went wrong')
+```
+
+### Child Loggers
+
+```typescript
+import { logger } from '@valian/pino-logger'
+
+// Create a child logger with bound context
+const requestLogger = logger.child({ requestId: 'abc-123' })
+
+requestLogger.info('Processing request') // includes requestId in output
+requestLogger.error({ statusCode: 500 }, 'Request failed')
+```
+
+### In Firebase Functions
+
+```typescript
+import { onRequest } from 'firebase-functions/v2/https'
+import { logger } from '@valian/pino-logger'
+
+export const myFunction = onRequest((request, response) => {
+  const reqLogger = logger.child({ path: request.path })
+
+  reqLogger.info('Function invoked')
+
+  try {
+    // Your function logic
+    reqLogger.debug({ query: request.query }, 'Processing request')
+    response.send('Success')
+  } catch (error) {
+    reqLogger.error(error, 'Function failed')
+    response.status(500).send('Error')
+  }
+})
+```
+
+## Configuration
+
+### Log Levels
+
+Control the minimum log level by setting the `LOG_LEVEL` environment variable:
+
+```bash
+# Available levels (in order of verbosity)
+LOG_LEVEL=trace  # Shows all logs
+LOG_LEVEL=debug  # Shows debug, info, warn, error, fatal (default)
+LOG_LEVEL=info   # Shows info, warn, error, fatal
+LOG_LEVEL=warn   # Shows warn, error, fatal
+LOG_LEVEL=error  # Shows error, fatal
+LOG_LEVEL=fatal  # Shows only fatal
+```
+
+### Environment Detection
+
+The logger automatically detects the environment:
+
+- **Development Mode**: Uses pino-pretty (if available) when:
+  - `FUNCTIONS_EMULATOR=true` (Firebase Emulator)
+  - `NODE_ENV=test` (Testing environment)
+  - `NODE_ENV=development` (Development environment)
+
+- **Production Mode**: Forwards logs to `firebase-functions/logger` for GCP-compatible structured logging
+
+## GCP Log Level Mapping
+
+In production, pino log levels are mapped to GCP Cloud Logging severity levels using a range-based approach that also supports custom levels:
+
+| Pino Level   | Level Number | GCP Severity |
+| ------------ | ------------ | ------------ |
+| trace        | 10           | DEBUG        |
+| debug        | 20           | DEBUG        |
+| info         | 30           | INFO         |
+| warn         | 40           | WARNING      |
+| error        | 50           | ERROR        |
+| fatal        | 60           | CRITICAL     |
+| custom (60+) | 60+          | CRITICAL     |
+
+The mapping uses ranges (`< 30` = DEBUG, `< 40` = INFO, etc.) to handle any numeric level, including custom pino levels.
+
+## How It Works
+
+In **development** (emulator, test, or development environment):
+
+- Uses `pino-pretty` for colorized, human-readable output
+- Logs directly to the console
+
+In **production** (deployed Firebase Functions):
+
+- Pino serializes logs to JSON
+- A custom destination stream parses the JSON and extracts the message and metadata
+- The log is forwarded to `firebase-functions/logger.write()` with the mapped GCP severity
+- Firebase's logger handles the structured logging format expected by GCP Cloud Logging
+
+```text
+┌─────────────────┐     ┌──────────────────┐     ┌─────────────────┐
+│  Application    │────>│  Pino Logger     │────>│  Firebase       │
+│  logger.info()  │     │  (JSON output)   │     │  Destination    │
+└─────────────────┘     └──────────────────┘     └────────┬────────┘
+                                                          │
+                                                          v
+                                               ┌─────────────────────┐
+                                               │ firebase-functions  │
+                                               │ logger.write()      │
+                                               └──────────┬──────────┘
+                                                          │
+                                                          v
+                                               ┌─────────────────────┐
+                                               │  GCP Cloud Logging  │
+                                               │  (Structured JSON)  │
+                                               └─────────────────────┘
+```
+
+## API Reference
+
+This package exports a pre-configured `pino.Logger` instance and a factory function. See the [pino documentation](https://getpino.io/) for the full API.
+
+### Exports
+
+#### `logger`
+
+A pre-configured pino logger instance ready to use.
+
+#### `createLogger(level?)`
+
+Factory function to create a custom logger with a specific log level.
+
+```typescript
+import { createLogger } from '@valian/pino-logger'
+
+const customLogger = createLogger('info') // Only logs info and above
+```
+
+### Common Methods
+
+#### `logger.trace(obj?, msg?, ...args)`
+
+#### `logger.debug(obj?, msg?, ...args)`
+
+#### `logger.info(obj?, msg?, ...args)`
+
+#### `logger.warn(obj?, msg?, ...args)`
+
+#### `logger.error(obj?, msg?, ...args)`
+
+#### `logger.fatal(obj?, msg?, ...args)`
+
+Log at the specified level. The first argument can be an object with context data.
+
+#### `logger.child(bindings)`
+
+Create a child logger with additional context that will be included in all log entries.
+
+## Development
+
+This library is part of the [firebase-functions](https://github.com/valian-ca/firebase-functions) monorepo.
+
+### Running Unit Tests
+
+```bash
+nx test pino-logger
+```
+
+Or using pnpm:
+
+```bash
+pnpm nx test pino-logger
+```
+
+## License
+
+MIT © [Valian](https://valian.ca)

--- a/packages/pino-logger/eslint.config.mjs
+++ b/packages/pino-logger/eslint.config.mjs
@@ -1,0 +1,15 @@
+import { base } from '@valian/eslint-config/base'
+import { importSort } from '@valian/eslint-config/import-sort'
+import { node } from '@valian/eslint-config/node'
+import { typescript } from '@valian/eslint-config/typescript'
+import { vitest } from '@valian/eslint-config/vitest'
+import { defineConfig, globalIgnores } from 'eslint/config'
+
+export default defineConfig([
+  base,
+  typescript,
+  importSort,
+  node,
+  vitest,
+  globalIgnores(['coverage/', 'dist/', 'lib/', 'out-tsc/']),
+])

--- a/packages/pino-logger/package.json
+++ b/packages/pino-logger/package.json
@@ -1,0 +1,76 @@
+{
+  "name": "@valian/pino-logger",
+  "version": "0.0.1",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/valian-ca/firebase-functions.git"
+  },
+  "author": {
+    "name": "Valian",
+    "organization": true,
+    "url": "https://valian.ca"
+  },
+  "contributors": [
+    {
+      "name": "Julien Marcil",
+      "email": "julien@valian.ca"
+    }
+  ],
+  "keywords": [
+    "firebase",
+    "pino",
+    "logger"
+  ],
+  "license": "MIT",
+  "peerDependencies": {
+    "firebase-functions": "^6.0.0",
+    "pino-pretty": "^13.0.0"
+  },
+  "dependencies": {
+    "pino": "^9.6.0"
+  },
+  "devDependencies": {
+    "firebase-functions": "6.3.2",
+    "pino-pretty": "13.1.3"
+  },
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": {
+        "types": {
+          "import": "./lib/index.d.mts",
+          "require": "./lib/index.d.cts"
+        },
+        "import": "./lib/index.mjs",
+        "require": "./lib/index.cjs",
+        "default": "./lib/index.mjs"
+      }
+    },
+    "main": "./lib/index.cjs",
+    "module": "./lib/index.mjs",
+    "types": "./lib/index.d.mts"
+  },
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "import": "./src/index.ts",
+      "default": "./src/index.ts"
+    },
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "lib",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsdown",
+    "prepack": "pnpm run build",
+    "lint:publint": "pnpm build && publint"
+  },
+  "engines": {
+    "node": ">=22.18"
+  }
+}

--- a/packages/pino-logger/src/__tests__/logger.spec.ts
+++ b/packages/pino-logger/src/__tests__/logger.spec.ts
@@ -1,0 +1,334 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+describe('logger', () => {
+  const originalEnv = process.env
+
+  beforeEach(() => {
+    // Reset modules before each test to allow re-importing with different env vars
+    vi.resetModules()
+    // Create a fresh copy of process.env
+    process.env = { ...originalEnv }
+  })
+
+  afterEach(() => {
+    // Restore original env
+    process.env = originalEnv
+    vi.restoreAllMocks()
+  })
+
+  describe('in emulator environment', () => {
+    it('should create a pino logger when FUNCTIONS_EMULATOR is true', async () => {
+      process.env.FUNCTIONS_EMULATOR = 'true'
+      process.env.LOG_LEVEL = 'debug'
+
+      const { logger } = await import('../logger.js')
+
+      expect(logger).toBeDefined()
+      expect(typeof logger.debug).toBe('function')
+      expect(typeof logger.info).toBe('function')
+      expect(typeof logger.warn).toBe('function')
+      expect(typeof logger.error).toBe('function')
+      expect(typeof logger.fatal).toBe('function')
+      expect(typeof logger.trace).toBe('function')
+    })
+
+    it('should log debug messages with LOG_LEVEL=debug', async () => {
+      process.env.FUNCTIONS_EMULATOR = 'true'
+      process.env.LOG_LEVEL = 'debug'
+
+      const { logger } = await import('../logger.js')
+
+      expect(() => {
+        logger.debug({ data: 'value' }, 'test debug message')
+      }).not.toThrow()
+    })
+
+    it('should log info messages with LOG_LEVEL=info', async () => {
+      process.env.FUNCTIONS_EMULATOR = 'true'
+      process.env.LOG_LEVEL = 'info'
+
+      const { logger } = await import('../logger.js')
+
+      expect(() => {
+        logger.info('test info message')
+      }).not.toThrow()
+    })
+
+    it('should log warn messages with LOG_LEVEL=warn', async () => {
+      process.env.FUNCTIONS_EMULATOR = 'true'
+      process.env.LOG_LEVEL = 'warn'
+
+      const { logger } = await import('../logger.js')
+
+      expect(() => {
+        logger.warn('test warn message')
+      }).not.toThrow()
+    })
+
+    it('should log error messages with LOG_LEVEL=error', async () => {
+      process.env.FUNCTIONS_EMULATOR = 'true'
+      process.env.LOG_LEVEL = 'error'
+
+      const { logger } = await import('../logger.js')
+
+      expect(() => {
+        logger.error(new Error('test error'), 'test error message')
+      }).not.toThrow()
+    })
+
+    it('should use default log level when LOG_LEVEL is not set', async () => {
+      process.env.FUNCTIONS_EMULATOR = 'true'
+      delete process.env.LOG_LEVEL
+
+      const { logger } = await import('../logger.js')
+
+      expect(() => {
+        logger.debug('test debug message')
+      }).not.toThrow()
+    })
+  })
+
+  describe('in test environment', () => {
+    it('should create a pino logger when NODE_ENV is test', async () => {
+      process.env.NODE_ENV = 'test'
+      delete process.env.FUNCTIONS_EMULATOR
+
+      const { logger } = await import('../logger.js')
+
+      expect(logger).toBeDefined()
+      expect(typeof logger.debug).toBe('function')
+    })
+
+    it('should log messages in test environment', async () => {
+      process.env.NODE_ENV = 'test'
+      process.env.LOG_LEVEL = 'debug'
+
+      const { logger } = await import('../logger.js')
+
+      expect(() => {
+        logger.debug('test message in test env')
+      }).not.toThrow()
+    })
+  })
+
+  describe('in development environment', () => {
+    it('should create a pino logger when NODE_ENV is development', async () => {
+      process.env.NODE_ENV = 'development'
+      delete process.env.FUNCTIONS_EMULATOR
+
+      const { logger } = await import('../logger.js')
+
+      expect(logger).toBeDefined()
+      expect(typeof logger.debug).toBe('function')
+    })
+
+    it('should log messages in development environment', async () => {
+      process.env.NODE_ENV = 'development'
+      delete process.env.FUNCTIONS_EMULATOR
+      process.env.LOG_LEVEL = 'debug'
+
+      const { logger } = await import('../logger.js')
+
+      expect(() => {
+        logger.info('test message in development')
+      }).not.toThrow()
+    })
+  })
+
+  describe('in production environment', () => {
+    it('should use firebase destination in production', async () => {
+      delete process.env.FUNCTIONS_EMULATOR
+      delete process.env.NODE_ENV
+
+      const { logger } = await import('../logger.js')
+
+      expect(logger).toBeDefined()
+      expect(typeof logger.debug).toBe('function')
+      expect(typeof logger.info).toBe('function')
+      expect(typeof logger.warn).toBe('function')
+      expect(typeof logger.error).toBe('function')
+    })
+
+    it('should have all pino logger methods in production', async () => {
+      delete process.env.FUNCTIONS_EMULATOR
+      delete process.env.NODE_ENV
+
+      const { logger } = await import('../logger.js')
+
+      // Test that all methods exist and are callable
+      expect(() => {
+        logger.debug('test')
+      }).not.toThrow()
+      expect(() => {
+        logger.info('test')
+      }).not.toThrow()
+      expect(() => {
+        logger.warn('test')
+      }).not.toThrow()
+      expect(() => {
+        logger.error('test')
+      }).not.toThrow()
+      expect(() => {
+        logger.fatal('test')
+      }).not.toThrow()
+    })
+
+    it('should forward logs with data to firebase logger', async () => {
+      delete process.env.FUNCTIONS_EMULATOR
+      delete process.env.NODE_ENV
+
+      const { logger } = await import('../logger.js')
+
+      // Test debug with data
+      expect(() => {
+        logger.debug({ userId: '123' }, 'debug with data')
+      }).not.toThrow()
+
+      // Test info with data
+      expect(() => {
+        logger.info({ action: 'login' }, 'info with data')
+      }).not.toThrow()
+
+      // Test warn with data
+      expect(() => {
+        logger.warn({ warning: 'high memory' }, 'warn with data')
+      }).not.toThrow()
+
+      // Test error with data
+      expect(() => {
+        logger.error({ errorCode: 500 }, 'error with data')
+      }).not.toThrow()
+    })
+
+    it('should handle messages without additional data', async () => {
+      delete process.env.FUNCTIONS_EMULATOR
+      delete process.env.NODE_ENV
+
+      const { logger } = await import('../logger.js')
+
+      // Test all levels without data
+      expect(() => {
+        logger.debug('debug message only')
+      }).not.toThrow()
+      expect(() => {
+        logger.info('info message only')
+      }).not.toThrow()
+      expect(() => {
+        logger.warn('warn message only')
+      }).not.toThrow()
+      expect(() => {
+        logger.error('error message only')
+      }).not.toThrow()
+    })
+
+    it('should handle object-only logs without message', async () => {
+      delete process.env.FUNCTIONS_EMULATOR
+      delete process.env.NODE_ENV
+
+      const { logger } = await import('../logger.js')
+
+      // Log only an object without a message string - tests the msg ?? '' fallback
+      expect(() => {
+        logger.info({ userId: '123', action: 'test' })
+      }).not.toThrow()
+    })
+
+    it('should handle malformed JSON gracefully', async () => {
+      delete process.env.FUNCTIONS_EMULATOR
+      delete process.env.NODE_ENV
+
+      // Import the destination directly by getting a fresh logger
+      const { createLogger } = await import('../logger.js')
+      const logger = createLogger()
+
+      // Mock JSON.parse to throw for pino log lines
+      const originalParse = JSON.parse
+      vi.spyOn(JSON, 'parse').mockImplementation((text: string): unknown => {
+        // Throw for any pino log line (contains "level" field)
+        if (typeof text === 'string' && text.includes('"level":')) {
+          throw new Error('Simulated JSON parse error')
+        }
+        return originalParse(text) as unknown
+      })
+
+      // This should not throw even when JSON.parse fails
+      expect(() => {
+        logger.info('malformed test')
+      }).not.toThrow()
+
+      vi.restoreAllMocks()
+    })
+  })
+
+  describe('pino logger features', () => {
+    it('should support object as first argument (pino style)', async () => {
+      process.env.FUNCTIONS_EMULATOR = 'true'
+      process.env.LOG_LEVEL = 'debug'
+
+      const { logger } = await import('../logger.js')
+
+      expect(() => {
+        logger.info({ key: 'value', another: 'object' }, 'message with context')
+      }).not.toThrow()
+    })
+
+    it('should handle nested objects', async () => {
+      process.env.FUNCTIONS_EMULATOR = 'true'
+      process.env.LOG_LEVEL = 'debug'
+
+      const { logger } = await import('../logger.js')
+
+      const complexObject = {
+        nested: {
+          deep: {
+            value: 'test',
+          },
+        },
+        array: [1, 2, 3],
+      }
+
+      expect(() => {
+        logger.debug(complexObject, 'complex data')
+      }).not.toThrow()
+    })
+
+    it('should handle Error objects', async () => {
+      process.env.FUNCTIONS_EMULATOR = 'true'
+      process.env.LOG_LEVEL = 'error'
+
+      const { logger } = await import('../logger.js')
+
+      const error = new Error('Test error')
+      error.stack = 'Error: Test error\n    at test.js:1:1'
+
+      expect(() => {
+        logger.error(error, 'Error occurred')
+      }).not.toThrow()
+    })
+
+    it('should support child loggers', async () => {
+      process.env.FUNCTIONS_EMULATOR = 'true'
+      process.env.LOG_LEVEL = 'debug'
+
+      const { logger } = await import('../logger.js')
+
+      const childLogger = logger.child({ requestId: '123' })
+
+      expect(childLogger).toBeDefined()
+      expect(() => {
+        childLogger.info('child logger message')
+      }).not.toThrow()
+    })
+
+    it('should support string-only messages', async () => {
+      process.env.FUNCTIONS_EMULATOR = 'true'
+      process.env.LOG_LEVEL = 'debug'
+
+      const { logger } = await import('../logger.js')
+
+      expect(() => {
+        logger.info('single message')
+      }).not.toThrow()
+    })
+  })
+})

--- a/packages/pino-logger/src/index.ts
+++ b/packages/pino-logger/src/index.ts
@@ -1,0 +1,1 @@
+export * from './logger'

--- a/packages/pino-logger/src/logger.ts
+++ b/packages/pino-logger/src/logger.ts
@@ -1,0 +1,72 @@
+import { logger as firebaseLogger } from 'firebase-functions'
+// eslint-disable-next-line import-x/no-named-as-default
+import pino, { type DestinationStream, type LevelWithSilentOrString } from 'pino'
+
+const isLocalEnvironment = () =>
+  process.env.FUNCTIONS_EMULATOR === 'true' || process.env.NODE_ENV === 'test' || process.env.NODE_ENV === 'development'
+
+type LogSeverity = 'DEBUG' | 'INFO' | 'NOTICE' | 'WARNING' | 'ERROR' | 'CRITICAL' | 'ALERT' | 'EMERGENCY'
+
+type PinoLogEntry = {
+  level: number
+  time: number
+  pid: number
+  hostname: string
+  msg?: string
+  [key: string]: unknown
+}
+
+/**
+ * Maps pino log level numbers to GCP LogSeverity.
+ * Uses ranges to handle any numeric level, including custom levels.
+ *
+ * Pino standard levels: 10=trace, 20=debug, 30=info, 40=warn, 50=error, 60=fatal
+ *
+ * @see https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#LogSeverity
+ */
+const pinoLevelToSeverity = (level: number): LogSeverity => {
+  if (level < 30) return 'DEBUG' // trace (10) and debug (20)
+  if (level < 40) return 'INFO' // info (30)
+  if (level < 50) return 'WARNING' // warn (40)
+  if (level < 60) return 'ERROR' // error (50)
+  return 'CRITICAL' // fatal (60+)
+}
+
+const firebaseDestination: DestinationStream = {
+  write(logLine) {
+    try {
+      const log = JSON.parse(logLine) as PinoLogEntry
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { level, time, pid, hostname, msg, ...rest } = log
+
+      firebaseLogger.write({
+        severity: pinoLevelToSeverity(level),
+        message: msg ?? '',
+        ...rest,
+      })
+    } catch {
+      // Fallback for malformed JSON - write raw log line
+      firebaseLogger.write({
+        severity: 'ERROR',
+        message: logLine,
+      })
+    }
+  },
+}
+
+export const createLogger = (level: LevelWithSilentOrString = process.env.LOG_LEVEL ?? 'debug') =>
+  isLocalEnvironment()
+    ? pino({
+        level,
+        transport: {
+          target: 'pino-pretty',
+          options: {
+            colorize: true,
+            translateTime: 'HH:MM:ss.l',
+            ignore: 'pid,hostname',
+          },
+        },
+      })
+    : pino({ level }, firebaseDestination)
+
+export const logger = createLogger()

--- a/packages/pino-logger/tsconfig.json
+++ b/packages/pino-logger/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/packages/pino-logger/tsconfig.lib.json
+++ b/packages/pino-logger/tsconfig.lib.json
@@ -1,0 +1,26 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "rootDir": "src",
+    "outDir": "dist",
+    "tsBuildInfoFile": "dist/tsconfig.lib.tsbuildinfo",
+    "types": ["node"]
+  },
+  "include": ["src"],
+  "references": [],
+  "exclude": [
+    "vite.config.ts",
+    "vite.config.mts",
+    "vitest.config.ts",
+    "vitest.config.mts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.test.tsx",
+    "src/**/*.spec.tsx",
+    "src/**/*.test.js",
+    "src/**/*.spec.js",
+    "src/**/*.test.jsx",
+    "src/**/*.spec.jsx"
+  ]
+}

--- a/packages/pino-logger/tsconfig.spec.json
+++ b/packages/pino-logger/tsconfig.spec.json
@@ -1,0 +1,27 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./out-tsc/vitest",
+    "types": ["vitest/globals", "vitest/importMeta", "node", "vitest"]
+  },
+  "include": [
+    "vite.config.ts",
+    "vite.config.mts",
+    "vitest.config.ts",
+    "vitest.config.mts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.test.tsx",
+    "src/**/*.spec.tsx",
+    "src/**/*.test.js",
+    "src/**/*.spec.js",
+    "src/**/*.test.jsx",
+    "src/**/*.spec.jsx",
+    "src/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/pino-logger/tsdown.config.mjs
+++ b/packages/pino-logger/tsdown.config.mjs
@@ -1,0 +1,10 @@
+import { defineConfig } from 'tsdown'
+
+export default defineConfig({
+  outDir: 'lib',
+  platform: 'node',
+  format: ['esm', 'cjs'],
+  target: 'es2022',
+  fixedExtension: true,
+  tsconfig: './tsconfig.lib.json',
+})

--- a/packages/pino-logger/vitest.config.mjs
+++ b/packages/pino-logger/vitest.config.mjs
@@ -1,0 +1,27 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    watch: false,
+    environment: 'node',
+    globals: false,
+    clearMocks: true,
+    coverage: {
+      enabled: true,
+      provider: 'v8',
+      reporter: ['text', 'cobertura'],
+      all: true,
+      include: ['src/**/*.ts'],
+      exclude: ['src/**/index.ts'],
+      thresholds: {
+        statements: 80,
+        branches: 85,
+        functions: 100,
+        lines: 80,
+      },
+    },
+    sequence: {
+      hooks: 'list',
+    },
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -79,6 +79,19 @@ importers:
         specifier: 7.0.3
         version: 7.0.3(firebase-admin@13.6.0)
 
+  packages/pino-logger:
+    dependencies:
+      pino:
+        specifier: ^9.6.0
+        version: 9.14.0
+    devDependencies:
+      firebase-functions:
+        specifier: 6.3.2
+        version: 6.3.2(firebase-admin@13.6.0)
+      pino-pretty:
+        specifier: 13.1.3
+        version: 13.1.3
+
   packages/sentry:
     dependencies:
       '@valian/function-logger':
@@ -1366,6 +1379,9 @@ packages:
     peerDependencies:
       typescript: ^3 || ^4 || ^5
 
+  '@pinojs/redact@0.4.0':
+    resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
+
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
 
@@ -2206,6 +2222,10 @@ packages:
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
+  atomic-sleep@1.0.0:
+    resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
+    engines: {node: '>=8.0.0'}
+
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
@@ -2369,6 +2389,9 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
+  colorette@2.0.20:
+    resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
+
   columnify@1.6.0:
     resolution: {integrity: sha512-lomjuFZKfM6MSAnV9aCZC9sc0qGbmZdfygNv+nCpqVkSKdCxCklLtd16O0EILGkImHw9ZpHkAnHaB+8Zxq5W6Q==}
     engines: {node: '>=8.0.0'}
@@ -2468,6 +2491,9 @@ packages:
   data-view-byte-offset@1.0.1:
     resolution: {integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==}
     engines: {node: '>= 0.4'}
+
+  dateformat@4.6.3:
+    resolution: {integrity: sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==}
 
   debug@2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
@@ -2863,6 +2889,9 @@ packages:
     resolution: {integrity: sha512-6ypT4XfgqJk/F3Yuv4SX26I3doUjt0GTG4a+JgWxXQpxXzTBq8fPUeGHfcYMMDPHJHm3yPOSjaeBwBGAHWXCdA==}
     engines: {node: '>=18.0.0'}
 
+  fast-copy@4.0.2:
+    resolution: {integrity: sha512-ybA6PDXIXOXivLJK/z9e+Otk7ve13I4ckBvGO5I2RRmBU1gMHLVDJYEuJYhGwez7YNlYji2M2DvVU+a9mSFDlw==}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -2871,6 +2900,9 @@ packages:
 
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
+  fast-safe-stringify@2.1.1:
+    resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
 
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
@@ -2925,6 +2957,13 @@ packages:
   firebase-admin@13.6.0:
     resolution: {integrity: sha512-GdPA/t0+Cq8p1JnjFRBmxRxAGvF/kl2yfdhALl38PrRp325YxyQ5aNaHui0XmaKcKiGRFIJ/EgBNWFoDP0onjw==}
     engines: {node: '>=18'}
+
+  firebase-functions@6.3.2:
+    resolution: {integrity: sha512-FC3A1/nhqt1ZzxRnj5HZLScQaozAcFSD/vSR8khqSoFNOfxuXgwJS6ZABTB7+v+iMD5z6Mmxw6OfqITUBuI7OQ==}
+    engines: {node: '>=14.10.0'}
+    hasBin: true
+    peerDependencies:
+      firebase-admin: ^11.10.0 || ^12.0.0 || ^13.0.0
 
   firebase-functions@7.0.3:
     resolution: {integrity: sha512-DiIjIUv0OS4KEAA3jqyIc7ymZKdcmMcaXy7FCCkrDQo/1CVMbDDWMdZIslmsgSjldA2nhau1dTE/6JQI8Urjjw==}
@@ -3131,6 +3170,9 @@ packages:
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
+
+  help-me@5.0.0:
+    resolution: {integrity: sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==}
 
   hermes-estree@0.25.1:
     resolution: {integrity: sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==}
@@ -3415,6 +3457,10 @@ packages:
 
   jose@4.15.9:
     resolution: {integrity: sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==}
+
+  joycon@3.1.1:
+    resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
+    engines: {node: '>=10'}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -3769,6 +3815,10 @@ packages:
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
+  on-exit-leak-free@2.1.2:
+    resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
+    engines: {node: '>=14.0.0'}
+
   on-finished@2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
     engines: {node: '>= 0.8'}
@@ -3874,6 +3924,23 @@ packages:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
 
+  pino-abstract-transport@2.0.0:
+    resolution: {integrity: sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==}
+
+  pino-abstract-transport@3.0.0:
+    resolution: {integrity: sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==}
+
+  pino-pretty@13.1.3:
+    resolution: {integrity: sha512-ttXRkkOz6WWC95KeY9+xxWL6AtImwbyMHrL1mSwqwW9u+vLp/WIElvHvCSDg0xO/Dzrggz1zv3rN5ovTRVowKg==}
+    hasBin: true
+
+  pino-std-serializers@7.1.0:
+    resolution: {integrity: sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==}
+
+  pino@9.14.0:
+    resolution: {integrity: sha512-8OEwKp5juEvb/MjpIc4hjqfgCNysrS94RIOMXYvpYCdm/jglrKEiAYmiumbmGhCvs+IcInsphYDFwqrjr7398w==}
+    hasBin: true
+
   pluralize@8.0.0:
     resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
     engines: {node: '>=4'}
@@ -3915,6 +3982,9 @@ packages:
     resolution: {integrity: sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
+  process-warning@5.0.0:
+    resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
+
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
@@ -3942,6 +4012,9 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  pump@3.0.3:
+    resolution: {integrity: sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
@@ -3952,6 +4025,9 @@ packages:
 
   quansync@1.0.0:
     resolution: {integrity: sha512-5xZacEEufv3HSTPQuchrvV6soaiACMFnq1H8wkVioctoH3TRha9Sz66lOxRwPK/qZj7HPiSveih9yAyh98gvqA==}
+
+  quick-format-unescaped@4.0.4:
+    resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
 
   range-parser@1.2.1:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
@@ -3970,6 +4046,10 @@ packages:
   readable-stream@3.6.2:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
     engines: {node: '>= 6'}
+
+  real-require@0.2.0:
+    resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
+    engines: {node: '>= 12.13.0'}
 
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
@@ -4102,8 +4182,15 @@ packages:
     resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
     engines: {node: '>= 0.4'}
 
+  safe-stable-stringify@2.5.0:
+    resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
+    engines: {node: '>=10'}
+
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  secure-json-parse@4.1.0:
+    resolution: {integrity: sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==}
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
@@ -4170,6 +4257,9 @@ packages:
   sirv@3.0.2:
     resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
     engines: {node: '>=18'}
+
+  sonic-boom@4.2.0:
+    resolution: {integrity: sha512-INb7TM37/mAcsGmc9hyyI6+QR3rR1zVRu36B0NeGXKnOOLiZOfER5SA+N7X7k3yUYRzLWafduTDvJAfDswwEww==}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -4255,6 +4345,10 @@ packages:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
 
+  strip-json-comments@5.0.3:
+    resolution: {integrity: sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==}
+    engines: {node: '>=14.16'}
+
   strnum@1.1.2:
     resolution: {integrity: sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==}
 
@@ -4284,6 +4378,9 @@ packages:
   text-extensions@2.4.0:
     resolution: {integrity: sha512-te/NtwBwfiNRLf9Ijqx3T0nlqZiQ2XrrtBvu+cLL8ZRrGkO0NHTug8MYFKyoSrv/sHTaSKfilUkizV6XhxMJ3g==}
     engines: {node: '>=8'}
+
+  thread-stream@3.1.0:
+    resolution: {integrity: sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==}
 
   through@2.3.8:
     resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
@@ -6256,6 +6353,8 @@ snapshots:
       esquery: 1.7.0
       typescript: 5.9.3
 
+  '@pinojs/redact@0.4.0': {}
+
   '@polka/url@1.0.0-next.29': {}
 
   '@prisma/instrumentation@6.19.0(@opentelemetry/api@1.9.0)':
@@ -7098,6 +7197,8 @@ snapshots:
 
   asynckit@0.4.0: {}
 
+  atomic-sleep@1.0.0: {}
+
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.1.0
@@ -7281,6 +7382,8 @@ snapshots:
 
   color-name@1.1.4: {}
 
+  colorette@2.0.20: {}
+
   columnify@1.6.0:
     dependencies:
       strip-ansi: 6.0.1
@@ -7386,6 +7489,8 @@ snapshots:
       call-bound: 1.0.4
       es-errors: 1.3.0
       is-data-view: 1.0.2
+
+  dateformat@4.6.3: {}
 
   debug@2.6.9:
     dependencies:
@@ -7937,11 +8042,15 @@ snapshots:
 
   farmhash-modern@1.1.0: {}
 
+  fast-copy@4.0.2: {}
+
   fast-deep-equal@3.1.3: {}
 
   fast-json-stable-stringify@2.1.0: {}
 
   fast-levenshtein@2.0.6: {}
+
+  fast-safe-stringify@2.1.1: {}
 
   fast-uri@3.1.0: {}
 
@@ -8015,6 +8124,17 @@ snapshots:
       '@google-cloud/storage': 7.18.0
     transitivePeerDependencies:
       - encoding
+      - supports-color
+
+  firebase-functions@6.3.2(firebase-admin@13.6.0):
+    dependencies:
+      '@types/cors': 2.8.19
+      '@types/express': 4.17.25
+      cors: 2.8.5
+      express: 4.22.1
+      firebase-admin: 13.6.0
+      protobufjs: 7.5.4
+    transitivePeerDependencies:
       - supports-color
 
   firebase-functions@7.0.3(firebase-admin@13.6.0):
@@ -8243,6 +8363,8 @@ snapshots:
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
+
+  help-me@5.0.0: {}
 
   hermes-estree@0.25.1: {}
 
@@ -8532,6 +8654,8 @@ snapshots:
   jiti@2.6.1: {}
 
   jose@4.15.9: {}
+
+  joycon@3.1.1: {}
 
   js-tokens@4.0.0: {}
 
@@ -8880,6 +9004,8 @@ snapshots:
 
   obug@2.1.1: {}
 
+  on-exit-leak-free@2.1.2: {}
+
   on-finished@2.4.1:
     dependencies:
       ee-first: 1.1.1
@@ -8987,6 +9113,46 @@ snapshots:
 
   picomatch@4.0.3: {}
 
+  pino-abstract-transport@2.0.0:
+    dependencies:
+      split2: 4.2.0
+
+  pino-abstract-transport@3.0.0:
+    dependencies:
+      split2: 4.2.0
+
+  pino-pretty@13.1.3:
+    dependencies:
+      colorette: 2.0.20
+      dateformat: 4.6.3
+      fast-copy: 4.0.2
+      fast-safe-stringify: 2.1.1
+      help-me: 5.0.0
+      joycon: 3.1.1
+      minimist: 1.2.8
+      on-exit-leak-free: 2.1.2
+      pino-abstract-transport: 3.0.0
+      pump: 3.0.3
+      secure-json-parse: 4.1.0
+      sonic-boom: 4.2.0
+      strip-json-comments: 5.0.3
+
+  pino-std-serializers@7.1.0: {}
+
+  pino@9.14.0:
+    dependencies:
+      '@pinojs/redact': 0.4.0
+      atomic-sleep: 1.0.0
+      on-exit-leak-free: 2.1.2
+      pino-abstract-transport: 2.0.0
+      pino-std-serializers: 7.1.0
+      process-warning: 5.0.0
+      quick-format-unescaped: 4.0.4
+      real-require: 0.2.0
+      safe-stable-stringify: 2.5.0
+      sonic-boom: 4.2.0
+      thread-stream: 3.1.0
+
   pluralize@8.0.0: {}
 
   possible-typed-array-names@1.1.0: {}
@@ -9016,6 +9182,8 @@ snapshots:
       '@jest/schemas': 30.0.5
       ansi-styles: 5.2.0
       react-is: 18.3.1
+
+  process-warning@5.0.0: {}
 
   prop-types@15.8.1:
     dependencies:
@@ -9059,6 +9227,11 @@ snapshots:
       picocolors: 1.1.1
       sade: 1.8.1
 
+  pump@3.0.3:
+    dependencies:
+      end-of-stream: 1.4.5
+      once: 1.4.0
+
   punycode@2.3.1: {}
 
   qs@6.14.1:
@@ -9066,6 +9239,8 @@ snapshots:
       side-channel: 1.1.0
 
   quansync@1.0.0: {}
+
+  quick-format-unescaped@4.0.4: {}
 
   range-parser@1.2.1: {}
 
@@ -9085,6 +9260,8 @@ snapshots:
       inherits: 2.0.4
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
+
+  real-require@0.2.0: {}
 
   reflect.getprototypeof@1.0.10:
     dependencies:
@@ -9288,7 +9465,11 @@ snapshots:
       es-errors: 1.3.0
       is-regex: 1.2.1
 
+  safe-stable-stringify@2.5.0: {}
+
   safer-buffer@2.1.2: {}
+
+  secure-json-parse@4.1.0: {}
 
   semver@6.3.1: {}
 
@@ -9389,6 +9570,10 @@ snapshots:
       mrmime: 2.0.1
       totalist: 3.0.1
 
+  sonic-boom@4.2.0:
+    dependencies:
+      atomic-sleep: 1.0.0
+
   source-map-js@1.2.1: {}
 
   source-map-support@0.5.19:
@@ -9487,6 +9672,8 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
+  strip-json-comments@5.0.3: {}
+
   strnum@1.1.2:
     optional: true
 
@@ -9522,6 +9709,10 @@ snapshots:
     optional: true
 
   text-extensions@2.4.0: {}
+
+  thread-stream@3.1.0:
+    dependencies:
+      real-require: 0.2.0
 
   through@2.3.8: {}
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./packages/sentry"
+    },
+    {
+      "path": "./packages/pino-logger"
     }
   ]
 }


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Adds a new `@valian/pino-logger` package to the monorepo that provides a pino-based logging solution for Firebase Functions. The implementation automatically switches between pretty console output in development and structured GCP logging in production via `firebase-functions/logger`. The package includes comprehensive test coverage, proper dual-format builds (ESM/CJS), and thorough documentation with usage examples and architecture diagrams.

<h3>Confidence Score: 4/5</h3>


- This PR is safe to merge with minor known concerns
- The implementation is solid with good test coverage and proper error handling. Previous review concerns about module-level imports and optional peer dependencies have been acknowledged by the team. The code quality is high with no new critical issues found.
- No files require special attention - previously identified concerns have been acknowledged

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/pino-logger/package.json | clean package configuration with proper peer dependencies and build setup |
| packages/pino-logger/src/logger.ts | implements pino logger with Firebase integration and proper severity mapping, though has known module-level import concerns |
| packages/pino-logger/src/__tests__/logger.spec.ts | comprehensive test coverage for logger behavior across environments, but lacks verification of actual Firebase logger integration |
| packages/pino-logger/README.md | detailed documentation with usage examples and architecture diagrams, though has known inaccuracy about GCP config package |

</details>



<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->